### PR TITLE
Upgrade to upstream dhall-kubernetes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+eval "$(lorri direnv)"

--- a/README.md
+++ b/README.md
@@ -13,27 +13,25 @@ This project relies upon resources provided by the [`dhall-kubernetes`](https://
 ## Install
 For stability, users are encouraged to import from a tagged release, not from the master branch, and to watch for new releases. This project does not yet have rigorous testing set up for it and new commits on the master branch are prone to break compatibility and are almost sure to change the import hash for the expression.
 ```
-https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v3.1.1/package.dhall sha256:1160d4c0f3d0f4750dd1644b2ba8351b197ebad4b1f577b42e7ae590f4706726
+https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v4.0.0/package.dhall sha256:bcfe5eed190f43f737a09bb2e40975cfd6fabc1f026c6475b012c263502a6210
 ```
 
 ## Example Usage
 ### Example ServiceMonitor
 ```dhall
-let kubernetes = https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/defaults.dhall sha256:4450e23dc81975d111650e06c0238862944bf699537af6cbacac9c7e471dfabe
+let Kubernetes = https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/506d633e382872346927b8cb9884d8b7382e6cab/package.dhall sha256:d9eac5668d5ed9cb3364c0a39721d4694e4247dad16d8a82827e4619ee1d6188
 
-let Kubernetes = https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/4ad58156b7fdbbb6da0543d8b314df899feca077/types.dhall sha256:e48e21b807dad217a6c3e631fcaf3e950062310bfb4a8bbcecc330eb7b2f60ed
-
-let PrometheusOperator = (https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v3.1.1/package.dhall sha256:1160d4c0f3d0f4750dd1644b2ba8351b197ebad4b1f577b42e7ae590f4706726).v1
+let PrometheusOperator = (https://raw.githubusercontent.com/coralogix/dhall-prometheus-operator/v4.0.0/package.dhall sha256:bcfe5eed190f43f737a09bb2e40975cfd6fabc1f026c6475b012c263502a6210).v1
 
 in PrometheusOperator.ServiceMonitor::{
    , metadata =
-         kubernetes.ObjectMeta // { name = "example" }
+         Kubernetes.ObjectMeta::{ name = "example" }
    , spec =
        PrometheusOperator.ServiceMonitorSpec::{
        , selector =
-             kubernetes.LabelSelector 
-          // { matchLabels =
-                toMap { app = "example" }
+             Kubernetes.LabelSelector::{
+             , matchLabels = Some
+                (toMap { app = "example" })
              }
        , endpoints =
          [ PrometheusOperator.Endpoint.Union.TargetPort

--- a/imports.dhall
+++ b/imports.dhall
@@ -1,5 +1,5 @@
 { Kubernetes =
-    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/381306bcc3fd87aafe042c23bb66fe58227b85f4/1.15/package.dhall sha256:271494d6e3daba2a47d9d023188e35bf44c9c477a1cfbad1c589695a6b626e56
+    https://raw.githubusercontent.com/dhall-lang/dhall-kubernetes/506d633e382872346927b8cb9884d8b7382e6cab/package.dhall sha256:d9eac5668d5ed9cb3364c0a39721d4694e4247dad16d8a82827e4619ee1d6188
 , Prelude =
     https://raw.githubusercontent.com/dhall-lang/dhall-lang/v14.0.0/Prelude/package.dhall sha256:c1b3fc613aabfb64a9e17f6c0d70fe82016a030beedd79851730993e9083fde2
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,29 @@
+let
+  nixpkgs = import (
+    let
+      version = "ef4b914b113119b7a70cf90b37496413d85723a3";
+    in builtins.fetchTarball {
+      name   = "nixpkgs-${version}";
+      url    = "https://github.com/NixOS/nixpkgs/archive/${version}.tar.gz";
+      sha256 = "1flgwivn53vk04svj4za39gg6g6r7r92g3y201h8cml0604gsmg8";
+    }
+  ) {};
+
+  dhall-haskell = import (
+    let
+      version = "1.30.0";
+    in nixpkgs.fetchFromGitHub {
+      owner           = "dhall-lang";
+      repo            = "dhall-haskell";
+      rev             = version;
+      fetchSubmodules = true;
+      sha256          = "1a662vwv7azdz77a1lwblqlpavh6dnf5idna932vhimnd03pczv4";
+    }
+  );
+
+in nixpkgs.mkShell {
+  buildInputs = [
+    dhall-haskell.dhall
+    nixpkgs.git
+  ];
+}

--- a/v1/AlertingSpec.dhall
+++ b/v1/AlertingSpec.dhall
@@ -1,8 +1,8 @@
 let AlertmanagerEndpoints = ./AlertmanagerEndpoints.dhall
 
 let AlertingSpec =
-      { Type = { alertmanagers : List AlertmanagerEndpoints.Type }
-      , default.alertmanagers = [] : List AlertmanagerEndpoints.Type
+      { Type = { alertmanagers : Optional (List AlertmanagerEndpoints.Type) }
+      , default.alertmanagers = None (List AlertmanagerEndpoints.Type)
       }
 
 let test = AlertingSpec::{=}

--- a/v1/Alertmanager.dhall
+++ b/v1/Alertmanager.dhall
@@ -6,23 +6,16 @@ let AlertmanagerSpec = ./AlertmanagerSpec.dhall
 
 let AlertmanagerStatus = ./AlertmanagerStatus.dhall
 
-let Alertmanager =
-      { Type =
-          { apiVersion : Text
-          , kind : Text
-          , metadata : Kubernetes.ObjectMeta.Type
-          , spec : AlertmanagerSpec.Type
-          , status : Optional AlertmanagerStatus.Type
-          }
-      , default =
-          { apiVersion = "monitoring.coreos.com/v1"
-          , kind = "Alertmanager"
-          , spec = AlertmanagerSpec::{=}
-          , status = None AlertmanagerStatus.Type
-          }
-      }
-
-let test =
-      Alertmanager::{ metadata = Kubernetes.ObjectMeta::{ name = "example" } }
-
-in  Alertmanager
+in  { Type =
+        { apiVersion : Text
+        , kind : Text
+        , metadata : Kubernetes.ObjectMeta.Type
+        , spec : AlertmanagerSpec.Type
+        , status : Optional AlertmanagerStatus.Type
+        }
+    , default =
+        { apiVersion = "monitoring.coreos.com/v1"
+        , kind = "Alertmanager"
+        , status = None AlertmanagerStatus.Type
+        }
+    }

--- a/v1/AlertmanagerEndpoints.dhall
+++ b/v1/AlertmanagerEndpoints.dhall
@@ -2,31 +2,21 @@ let IntOrString = (../imports.dhall).Kubernetes.IntOrString
 
 let TLSConfig = ./TLSConfig.dhall
 
-let AlertmanagerEndpoints =
-      { Type =
-          { namespace : Text
-          , name : Text
-          , port : IntOrString
-          , scheme : Optional Text
-          , pathPrefix : Optional Text
-          , tlsConfig : Optional TLSConfig.Type
-          , bearerTokenFile : Optional Text
-          , apiVersion : Optional Text
-          }
-      , default =
-          { scheme = None Text
-          , pathPrefix = None Text
-          , tlsConfig = None TLSConfig.Type
-          , bearerTokenFile = None Text
-          , apiVersion = None Text
-          }
-      }
-
-let test =
-      AlertmanagerEndpoints::{
-      , namespace = "default"
-      , name = "example"
-      , port = IntOrString.String "example"
-      }
-
-in  AlertmanagerEndpoints
+in  { Type =
+        { namespace : Text
+        , name : Text
+        , port : IntOrString
+        , scheme : Optional Text
+        , pathPrefix : Optional Text
+        , tlsConfig : Optional TLSConfig.Type
+        , bearerTokenFile : Optional Text
+        , apiVersion : Optional Text
+        }
+    , default =
+        { scheme = None Text
+        , pathPrefix = None Text
+        , tlsConfig = None TLSConfig.Type
+        , bearerTokenFile = None Text
+        , apiVersion = None Text
+        }
+    }

--- a/v1/AlertmanagerList.dhall
+++ b/v1/AlertmanagerList.dhall
@@ -1,4 +1,4 @@
-let ListMeta = (../imports.dhall).Kubernetes.ListMeta
+let ListMeta = (../imports.dhall).Kubernetes.ListMeta.Type
 
 let Alertmanager = ./Alertmanager.dhall
 
@@ -6,14 +6,14 @@ let AlertmanagerList =
       { Type =
           { apiVersion : Text
           , kind : Text
-          , metadata : Optional ListMeta.Type
-          , items : List Alertmanager.Type
+          , metadata : Optional ListMeta
+          , items : Optional (List Alertmanager.Type)
           }
       , default =
           { apiVersion = "monitoring.coreos.com/v1"
           , kind = "AlertmanagerList"
-          , metadata = None ListMeta.Type
-          , items = [] : List Alertmanager.Type
+          , metadata = None ListMeta
+          , items = None (List Alertmanager.Type)
           }
       }
 

--- a/v1/AlertmanagerSpec.dhall
+++ b/v1/AlertmanagerSpec.dhall
@@ -14,31 +14,32 @@ let AlertmanagerSpec =
           , tag : Optional Text
           , sha : Optional Text
           , baseImage : Optional Text
-          , imagePullSecrets : List Kubernetes.LocalObjectReference.Type
-          , secrets : List Text
-          , configMaps : List Text
+          , imagePullSecrets :
+              Optional (List Kubernetes.LocalObjectReference.Type)
+          , secrets : Optional (List Text)
+          , configMaps : Optional (List Text)
           , configSecret : Optional Text
           , logLevel : Optional Text
           , logFormat : Optional Text
           , replicas : Optional Natural
           , retention : Optional Text
           , storage : Optional StorageSpec
-          , volumes : List Kubernetes.Volume.Type
-          , volumeMounts : List Kubernetes.VolumeMount.Type
+          , volumes : Optional (List Kubernetes.Volume.Type)
+          , volumeMounts : Optional (List Kubernetes.VolumeMount.Type)
           , externalUrl : Optional Text
           , routePrefix : Optional Text
           , paused : Optional Bool
-          , nodeSelector : Map Text Text
+          , nodeSelector : Optional (Map Text Text)
           , resources : Optional Kubernetes.ResourceRequirements.Type
           , affinity : Optional Kubernetes.Affinity.Type
-          , tolerations : List Kubernetes.Toleration.Type
+          , tolerations : Optional (List Kubernetes.Toleration.Type)
           , securityContext : Optional Kubernetes.PodSecurityContext.Type
           , serviceAccountName : Optional Text
           , listenLocal : Optional Bool
-          , containers : List Kubernetes.Container.Type
-          , initContainers : List Kubernetes.Container.Type
+          , containers : Optional (List Kubernetes.Container.Type)
+          , initContainers : Optional (List Kubernetes.Container.Type)
           , priorityClassName : Optional Text
-          , additionalPeers : List Text
+          , additionalPeers : Optional (List Text)
           , portName : Optional Text
           }
       , default =
@@ -48,31 +49,31 @@ let AlertmanagerSpec =
           , tag = None Text
           , sha = None Text
           , baseImage = None Text
-          , imagePullSecrets = [] : List Kubernetes.LocalObjectReference.Type
-          , secrets = [] : List Text
-          , configMaps = [] : List Text
+          , imagePullSecrets = None (List Kubernetes.LocalObjectReference.Type)
+          , secrets = None (List Text)
+          , configMaps = None (List Text)
           , configSecret = None Text
           , logLevel = None Text
           , logFormat = None Text
           , replicas = None Natural
           , retention = None Text
           , storage = None StorageSpec
-          , volumes = [] : List Kubernetes.Volume.Type
-          , volumeMounts = [] : List Kubernetes.VolumeMount.Type
+          , volumes = None (List Kubernetes.Volume.Type)
+          , volumeMounts = None (List Kubernetes.VolumeMount.Type)
           , externalUrl = None Text
           , routePrefix = None Text
           , paused = None Bool
-          , nodeSelector = [] : Map Text Text
+          , nodeSelector = None (Map Text Text)
           , resources = None Kubernetes.ResourceRequirements.Type
           , affinity = None Kubernetes.Affinity.Type
-          , tolerations = [] : List Kubernetes.Toleration.Type
+          , tolerations = None (List Kubernetes.Toleration.Type)
           , securityContext = None Kubernetes.PodSecurityContext.Type
           , serviceAccountName = None Text
           , listenLocal = None Bool
-          , containers = [] : List Kubernetes.Container.Type
-          , initContainers = [] : List Kubernetes.Container.Type
+          , containers = None (List Kubernetes.Container.Type)
+          , initContainers = None (List Kubernetes.Container.Type)
           , priorityClassName = None Text
-          , additionalPeers = [] : List Text
+          , additionalPeers = None (List Text)
           , portName = None Text
           }
       }

--- a/v1/Endpoint.dhall
+++ b/v1/Endpoint.dhall
@@ -13,7 +13,7 @@ let TLSConfig = ./TLSConfig.dhall
 let Common =
         { path : Optional Text
         , scheme : Optional Text
-        , params : Map Text Text
+        , params : Optional (Map Text Text)
         , interval : Optional Text
         , scrapeTimeout : Optional Text
         , tlsConfig : Optional TLSConfig.Type
@@ -22,8 +22,8 @@ let Common =
         , honorLabels : Optional Bool
         , honorTimestamps : Optional Bool
         , basicAuth : Optional BasicAuth.Type
-        , metricRelabelings : List RelabelConfig.Type
-        , relabelings : List RelabelConfig.Type
+        , metricRelabelings : Optional (List RelabelConfig.Type)
+        , relabelings : Optional (List RelabelConfig.Type)
         , proxyUrl : Optional Text
         }
       : Type
@@ -31,7 +31,7 @@ let Common =
 let common =
       { path = None Text
       , scheme = None Text
-      , params = [] : Map Text Text
+      , params = None (Map Text Text)
       , interval = None Text
       , scrapeTimeout = None Text
       , tlsConfig = None TLSConfig.Type
@@ -40,8 +40,8 @@ let common =
       , honorLabels = None Bool
       , honorTimestamps = None Bool
       , basicAuth = None BasicAuth.Type
-      , metricRelabelings = [] : List RelabelConfig.Type
-      , relabelings = [] : List RelabelConfig.Type
+      , metricRelabelings = None (List RelabelConfig.Type)
+      , relabelings = None (List RelabelConfig.Type)
       , proxyUrl = None Text
       }
 

--- a/v1/PodMetricsEndpoint.dhall
+++ b/v1/PodMetricsEndpoint.dhall
@@ -6,37 +6,32 @@ let Prelude = imports.Prelude
 
 let RelabelConfig = (./RelabelConfig.dhall).Type
 
-let PodMetricsEndpoint =
-      { Type =
-          { port : Optional Text
-          , targetPort : Optional Kubernetes.IntOrString
-          , path : Optional Text
-          , scheme : Optional Text
-          , params : Optional (Prelude.Map.Type Text Text)
-          , interval : Optional Text
-          , scrapeTimeout : Optional Text
-          , honorLabels : Optional Bool
-          , honorTimestamps : Optional Bool
-          , metricRelabelings : List RelabelConfig
-          , relabelings : List RelabelConfig
-          , proxyUrl : Optional Text
-          }
-      , default =
-          { port = None Text
-          , targetPort = None Kubernetes.IntOrString
-          , path = None Text
-          , scheme = None Text
-          , params = None (Prelude.Map.Type Text Text)
-          , interval = None Text
-          , scrapeTimeout = None Text
-          , honorLabels = None Bool
-          , honorTimestamps = None Bool
-          , metricRelabelings = [] : List RelabelConfig
-          , relabelings = [] : List RelabelConfig
-          , proxyUrl = None Text
-          }
-      }
-
-let test = PodMetricsEndpoint::{=}
-
-in  PodMetricsEndpoint
+in  { Type =
+        { port : Optional Text
+        , targetPort : Optional Kubernetes.IntOrString
+        , path : Optional Text
+        , scheme : Optional Text
+        , params : Optional (Prelude.Map.Type Text Text)
+        , interval : Optional Text
+        , scrapeTimeout : Optional Text
+        , honorLabels : Optional Bool
+        , honorTimestamps : Optional Bool
+        , metricRelabelings : Optional (List RelabelConfig)
+        , relabelings : Optional (List RelabelConfig)
+        , proxyUrl : Optional Text
+        }
+    , default =
+        { port = None Text
+        , targetPort = None Kubernetes.IntOrString
+        , path = None Text
+        , scheme = None Text
+        , params = None (Prelude.Map.Type Text Text)
+        , interval = None Text
+        , scrapeTimeout = None Text
+        , honorLabels = None Bool
+        , honorTimestamps = None Bool
+        , metricRelabelings = None (List RelabelConfig)
+        , relabelings = None (List RelabelConfig)
+        , proxyUrl = None Text
+        }
+    }

--- a/v1/PodMonitor.dhall
+++ b/v1/PodMonitor.dhall
@@ -1,27 +1,12 @@
 let Kubernetes = (../imports.dhall).Kubernetes
 
-let PodMetricsEndpoint = ./PodMetricsEndpoint.dhall
-
 let PodMonitorSpec = ./PodMonitorSpec.dhall
 
-let PodMonitor =
-      { Type =
-          { apiVersion : Text
-          , kind : Text
-          , metadata : Kubernetes.ObjectMeta.Type
-          , spec : PodMonitorSpec.Type
-          }
-      , default =
-          { apiVersion = "monitoring.coreos.com/v1", kind = "PodMonitor" }
-      }
-
-let test =
-      PodMonitor::{
-      , metadata = Kubernetes.ObjectMeta::{ name = "example" }
-      , spec = PodMonitorSpec::{
-        , podMetricsEndpoints = [ PodMetricsEndpoint::{=} ]
-        , selector = Kubernetes.LabelSelector::{=}
+in  { Type =
+        { apiVersion : Text
+        , kind : Text
+        , metadata : Kubernetes.ObjectMeta.Type
+        , spec : PodMonitorSpec.Type
         }
-      }
-
-in  PodMonitor
+    , default = { apiVersion = "monitoring.coreos.com/v1", kind = "PodMonitor" }
+    }

--- a/v1/PodMonitorList.dhall
+++ b/v1/PodMonitorList.dhall
@@ -2,20 +2,12 @@ let Kubernetes = (../imports.dhall).Kubernetes
 
 let PodMonitor = ./PodMonitor.dhall
 
-let PodMonitorList =
-      { Type =
-          { apiVersion : Text
-          , kind : Text
-          , metadata : Kubernetes.ListMeta.Type
-          , items : List PodMonitor.Type
-          }
-      , default =
-          { apiVersion = "monitoring.coreos.com/v1"
-          , kind = "PodMonitorList"
-          , items = [] : List PodMonitor.Type
-          }
-      }
-
-let test = PodMonitorList::{ metadata = Kubernetes.ListMeta::{=} }
-
-in  PodMonitorList
+in  { Type =
+        { apiVersion : Text
+        , kind : Text
+        , metadata : Kubernetes.ListMeta.Type
+        , items : Optional (List PodMonitor.Type)
+        }
+    , default =
+        { apiVersion = "monitoring.coreos.com/v1", kind = "PodMonitorList" }
+    }

--- a/v1/PodMonitorSpec.dhall
+++ b/v1/PodMonitorSpec.dhall
@@ -6,27 +6,18 @@ let PodMetricsEndpoint = ./PodMetricsEndpoint.dhall
 
 let NamespaceSelector = ./NamespaceSelector.dhall
 
-let PodMonitorSpec =
-      { Type =
-          { jobLabel : Optional Text
-          , podTargetLabels : List Text
-          , podMetricsEndpoints : List PodMetricsEndpoint.Type
-          , selector : Kubernetes.LabelSelector.Type
-          , namespaceSelector : Optional NamespaceSelector
-          , sampleLimit : Optional Natural
-          }
-      , default =
-          { jobLabel = None Text
-          , podTargetLabels = [] : List Text
-          , namespaceSelector = None NamespaceSelector
-          , sampleLimit = None Natural
-          }
-      }
-
-let test =
-      PodMonitorSpec::{
-      , podMetricsEndpoints = [ PodMetricsEndpoint::{=} ]
-      , selector = Kubernetes.LabelSelector::{=}
-      }
-
-in  PodMonitorSpec
+in  { Type =
+        { jobLabel : Optional Text
+        , podTargetLabels : Optional (List Text)
+        , podMetricsEndpoints : Optional (List PodMetricsEndpoint.Type)
+        , selector : Kubernetes.LabelSelector.Type
+        , namespaceSelector : Optional NamespaceSelector
+        , sampleLimit : Optional Natural
+        }
+    , default =
+        { jobLabel = None Text
+        , podTargetLabels = None (List Text)
+        , namespaceSelector = None NamespaceSelector
+        , sampleLimit = None Natural
+        }
+    }

--- a/v1/Prometheus.dhall
+++ b/v1/Prometheus.dhall
@@ -6,24 +6,16 @@ let PrometheusSpec = ./PrometheusSpec.dhall
 
 let PrometheusStatus = ./PrometheusStatus.dhall
 
-let Prometheus =
-      { Type =
-          { apiVersion : Text
-          , kind : Text
-          , metadata : Kubernetes.ObjectMeta.Type
-          , spec : PrometheusSpec.Type
-          , status : Optional PrometheusStatus.Type
-          }
-      , default =
-          { apiVersion = "monitoring.coreos.com/v1"
-          , kind = "Prometheus"
-          , metadata = Kubernetes.ObjectMeta.Type
-          , spec = PrometheusSpec::{=}
-          , status = None PrometheusStatus.Type
-          }
-      }
-
-let test =
-      Prometheus::{ metadata = Kubernetes.ObjectMeta::{ name = "example" } }
-
-in  Prometheus
+in  { Type =
+        { apiVersion : Text
+        , kind : Text
+        , metadata : Kubernetes.ObjectMeta.Type
+        , spec : PrometheusSpec.Type
+        , status : Optional PrometheusStatus.Type
+        }
+    , default =
+        { apiVersion = "monitoring.coreos.com/v1"
+        , kind = "Prometheus"
+        , status = None PrometheusStatus.Type
+        }
+    }

--- a/v1/PrometheusList.dhall
+++ b/v1/PrometheusList.dhall
@@ -2,21 +2,12 @@ let Kubernetes = (../imports.dhall).Kubernetes
 
 let Prometheus = ./Prometheus.dhall
 
-let PrometheusList =
-      { Type =
-          { apiVersion : Text
-          , kind : Text
-          , metadata : Optional Kubernetes.ListMeta.Type
-          , items : List Prometheus.Type
-          }
-      , default =
-          { apiVersion = "monitoring.coreos.com/v1"
-          , kind = "PrometheusList"
-          , metadata = None Kubernetes.ListMeta.Type
-          , items = [] : List Prometheus.Type
-          }
-      }
-
-let test = PrometheusList::{=}
-
-in  PrometheusList
+in  { Type =
+        { apiVersion : Text
+        , kind : Text
+        , metadata : Kubernetes.ListMeta.Type
+        , items : Optional (List Prometheus.Type)
+        }
+    , default =
+        { apiVersion = "monitoring.coreos.com/v1", kind = "PrometheusList" }
+    }

--- a/v1/PrometheusRule.dhall
+++ b/v1/PrometheusRule.dhall
@@ -4,22 +4,12 @@ let Kubernetes = imports.Kubernetes
 
 let PrometheusRuleSpec = ./PrometheusRuleSpec.dhall
 
-let PrometheusRule =
-      { Type =
-          { apiVersion : Text
-          , kind : Text
-          , metadata : Kubernetes.ObjectMeta.Type
-          , spec : PrometheusRuleSpec.Type
-          }
-      , default =
-          { apiVersion = "monitoring.coreos.com/v1"
-          , kind = "PrometheusRule"
-          , metadata = Kubernetes.ObjectMeta.Type
-          , spec = PrometheusRuleSpec::{=}
-          }
-      }
-
-let test =
-      PrometheusRule::{ metadata = Kubernetes.ObjectMeta::{ name = "example" } }
-
-in  PrometheusRule
+in  { Type =
+        { apiVersion : Text
+        , kind : Text
+        , metadata : Kubernetes.ObjectMeta.Type
+        , spec : PrometheusRuleSpec.Type
+        }
+    , default =
+        { apiVersion = "monitoring.coreos.com/v1", kind = "PrometheusRule" }
+    }

--- a/v1/PrometheusRuleList.dhall
+++ b/v1/PrometheusRuleList.dhall
@@ -2,21 +2,12 @@ let Kubernetes = (../imports.dhall).Kubernetes
 
 let PrometheusRule = ./PrometheusRule.dhall
 
-let PrometheusRuleList =
-      { Type =
-          { apiVersion : Text
-          , kind : Text
-          , metadata : Optional Kubernetes.ListMeta.Type
-          , items : List PrometheusRule.Type
-          }
-      , default =
-          { apiVersion = "monitoring.coreos.com/v1"
-          , kind = "PrometheusRuleList"
-          , metadata = None Kubernetes.ListMeta.Type
-          , items = [] : List PrometheusRule.Type
-          }
-      }
-
-let test = PrometheusRuleList::{=}
-
-in  PrometheusRuleList
+in  { Type =
+        { apiVersion : Text
+        , kind : Text
+        , metadata : Kubernetes.ListMeta.Type
+        , items : Optional (List PrometheusRule.Type)
+        }
+    , default =
+        { apiVersion = "monitoring.coreos.com/v1", kind = "PrometheusRuleList" }
+    }

--- a/v1/PrometheusSpec.dhall
+++ b/v1/PrometheusSpec.dhall
@@ -25,138 +25,132 @@ let ThanosSpec = ./ThanosSpec.dhall
 
 let NamespaceSelector = ./NamespaceSelector.dhall
 
-let PrometheusSpec =
-      { Type =
-          { podMetadata : Optional Kubernetes.ObjectMeta.Type
-          , serviceMonitorSelector : Optional Kubernetes.LabelSelector.Type
-          , serviceMonitorNamespaceSelector :
-              Optional Kubernetes.LabelSelector.Type
-          , podMonitorSelector : Optional Kubernetes.LabelSelector.Type
-          , podMonitorNamespaceSelector : Optional Kubernetes.LabelSelector.Type
-          , version : Optional Text
-          , tag : Optional Text
-          , sha : Optional Text
-          , paused : Optional Bool
-          , image : Optional Text
-          , baseImage : Optional Text
-          , imagePullSecrets : List Kubernetes.LocalObjectReference.Type
-          , replicas : Optional Natural
-          , replicaExternalLabelName : Optional Text
-          , prometheusExternalLabelName : Optional Text
-          , retention : Optional Text
-          , retentionSize : Optional Text
-          , disableCompaction : Optional Bool
-          , walCompression : Optional Bool
-          , logLevel : Optional Text
-          , logFormat : Optional Text
-          , scrapeInterval : Optional Text
-          , evaluationInterval : Optional Text
-          , rules : Optional Rules.Type
-          , externalLabels : Map Text Text
-          , enableAdminAPI : Optional Bool
-          , externalUrl : Optional Text
-          , routePrefix : Optional Text
-          , query : Optional QuerySpec.Type
-          , storage : Optional StorageSpec
-          , volumes : List Kubernetes.Volume.Type
-          , ruleSelector : Optional Kubernetes.LabelSelector.Type
-          , ruleNamespaceSelector : Optional Kubernetes.LabelSelector.Type
-          , alerting : Optional AlertingSpec.Type
-          , resources : Optional Kubernetes.ResourceRequirements.Type
-          , nodeSelector : Map Text Text
-          , serviceAccountName : Optional Text
-          , secrets : List Text
-          , configMaps : List Text
-          , affinity : Optional Kubernetes.Affinity.Type
-          , tolerations : List Kubernetes.Toleration.Type
-          , remoteWrite : List RemoteWriteSpec.Type
-          , remoteRead : List RemoteReadSpec.Type
-          , securityContext : Optional Kubernetes.PodSecurityContext.Type
-          , listenLocal : Optional Bool
-          , containers : List Kubernetes.Container.Type
-          , initContainers : List Kubernetes.Container.Type
-          , additionalScrapeConfigs : Optional Kubernetes.SecretKeySelector.Type
-          , additionalAlertRelabelConfigs :
-              Optional Kubernetes.SecretKeySelector.Type
-          , additionalAlertManagerConfigs :
-              Optional Kubernetes.SecretKeySelector.Type
-          , apiserverConfig : Optional APIServerConfig.Union
-          , thanos : Optional ThanosSpec.Type
-          , priorityClassName : Optional Text
-          , portName : Optional Text
-          , arbitraryFSAccessThroughSMs :
-              Optional ArbitraryFSAccessThroughSMsConfig.Type
-          , overrideHonorLabels : Optional Bool
-          , overrideHonorTimestamps : Optional Bool
-          , ignoreNamespaceSelectors : Optional Bool
-          , enforcedNamespaceLabel : Optional Text
-          }
-      , default =
-          { podMetadata = None Kubernetes.ObjectMeta.Type
-          , serviceMonitorSelector = None Kubernetes.LabelSelector.Type
-          , serviceMonitorNamespaceSelector = None Kubernetes.LabelSelector.Type
-          , podMonitorSelector = None Kubernetes.LabelSelector.Type
-          , podMonitorNamespaceSelector = None Kubernetes.LabelSelector.Type
-          , version = None Text
-          , tag = None Text
-          , sha = None Text
-          , paused = None Bool
-          , image = None Text
-          , baseImage = None Text
-          , imagePullSecrets = [] : List Kubernetes.LocalObjectReference.Type
-          , replicas = None Natural
-          , replicaExternalLabelName = None Text
-          , prometheusExternalLabelName = None Text
-          , retention = None Text
-          , retentionSize = None Text
-          , disableCompaction = None Bool
-          , walCompression = None Bool
-          , logLevel = None Text
-          , logFormat = None Text
-          , scrapeInterval = None Text
-          , evaluationInterval = None Text
-          , rules = None Rules.Type
-          , externalLabels = [] : Map Text Text
-          , enableAdminAPI = None Bool
-          , externalUrl = None Text
-          , routePrefix = None Text
-          , query = None QuerySpec.Type
-          , storage = None StorageSpec
-          , volumes = [] : List Kubernetes.Volume.Type
-          , ruleSelector = None Kubernetes.LabelSelector.Type
-          , ruleNamespaceSelector = None Kubernetes.LabelSelector.Type
-          , alerting = None AlertingSpec.Type
-          , resources = None Kubernetes.ResourceRequirements.Type
-          , nodeSelector = [] : Map Text Text
-          , serviceAccountName = None Text
-          , secrets = [] : List Text
-          , configMaps = [] : List Text
-          , affinity = None Kubernetes.Affinity.Type
-          , tolerations = [] : List Kubernetes.Toleration.Type
-          , remoteWrite = [] : List RemoteWriteSpec.Type
-          , remoteRead = [] : List RemoteReadSpec.Type
-          , securityContext = None Kubernetes.PodSecurityContext.Type
-          , listenLocal = None Bool
-          , containers = [] : List Kubernetes.Container.Type
-          , initContainers = [] : List Kubernetes.Container.Type
-          , additionalScrapeConfigs = None Kubernetes.SecretKeySelector.Type
-          , additionalAlertRelabelConfigs =
-              None Kubernetes.SecretKeySelector.Type
-          , additionalAlertManagerConfigs =
-              None Kubernetes.SecretKeySelector.Type
-          , apiserverConfig = None APIServerConfig.Union
-          , thanos = None ThanosSpec.Type
-          , priorityClassName = None Text
-          , portName = None Text
-          , arbitraryFSAccessThroughSMs =
-              None ArbitraryFSAccessThroughSMsConfig.Type
-          , overrideHonorLabels = None Bool
-          , overrideHonorTimestamps = None Bool
-          , ignoreNamespaceSelectors = None Bool
-          , enforcedNamespaceLabel = None Text
-          }
-      }
-
-let test = PrometheusSpec::{=}
-
-in  PrometheusSpec
+in  { Type =
+        { podMetadata : Optional Kubernetes.ObjectMeta.Type
+        , serviceMonitorSelector : Optional Kubernetes.LabelSelector.Type
+        , serviceMonitorNamespaceSelector :
+            Optional Kubernetes.LabelSelector.Type
+        , podMonitorSelector : Optional Kubernetes.LabelSelector.Type
+        , podMonitorNamespaceSelector : Optional Kubernetes.LabelSelector.Type
+        , version : Optional Text
+        , tag : Optional Text
+        , sha : Optional Text
+        , paused : Optional Bool
+        , image : Optional Text
+        , baseImage : Optional Text
+        , imagePullSecrets :
+            Optional (List Kubernetes.LocalObjectReference.Type)
+        , replicas : Optional Natural
+        , replicaExternalLabelName : Optional Text
+        , prometheusExternalLabelName : Optional Text
+        , retention : Optional Text
+        , retentionSize : Optional Text
+        , disableCompaction : Optional Bool
+        , walCompression : Optional Bool
+        , logLevel : Optional Text
+        , logFormat : Optional Text
+        , scrapeInterval : Optional Text
+        , evaluationInterval : Optional Text
+        , rules : Optional Rules.Type
+        , externalLabels : Optional (Map Text Text)
+        , enableAdminAPI : Optional Bool
+        , externalUrl : Optional Text
+        , routePrefix : Optional Text
+        , query : Optional QuerySpec.Type
+        , storage : Optional StorageSpec
+        , volumes : Optional (List Kubernetes.Volume.Type)
+        , ruleSelector : Optional Kubernetes.LabelSelector.Type
+        , ruleNamespaceSelector : Optional Kubernetes.LabelSelector.Type
+        , alerting : Optional AlertingSpec.Type
+        , resources : Optional Kubernetes.ResourceRequirements.Type
+        , nodeSelector : Optional (Map Text Text)
+        , serviceAccountName : Optional Text
+        , secrets : Optional (List Text)
+        , configMaps : Optional (List Text)
+        , affinity : Optional Kubernetes.Affinity.Type
+        , tolerations : Optional (List Kubernetes.Toleration.Type)
+        , remoteWrite : Optional (List RemoteWriteSpec.Type)
+        , remoteRead : Optional (List RemoteReadSpec.Type)
+        , securityContext : Optional Kubernetes.PodSecurityContext.Type
+        , listenLocal : Optional Bool
+        , containers : Optional (List Kubernetes.Container.Type)
+        , initContainers : Optional (List Kubernetes.Container.Type)
+        , additionalScrapeConfigs : Optional Kubernetes.SecretKeySelector.Type
+        , additionalAlertRelabelConfigs :
+            Optional Kubernetes.SecretKeySelector.Type
+        , additionalAlertManagerConfigs :
+            Optional Kubernetes.SecretKeySelector.Type
+        , apiserverConfig : Optional APIServerConfig.Union
+        , thanos : Optional ThanosSpec.Type
+        , priorityClassName : Optional Text
+        , portName : Optional Text
+        , arbitraryFSAccessThroughSMs :
+            Optional ArbitraryFSAccessThroughSMsConfig.Type
+        , overrideHonorLabels : Optional Bool
+        , overrideHonorTimestamps : Optional Bool
+        , ignoreNamespaceSelectors : Optional Bool
+        , enforcedNamespaceLabel : Optional Text
+        }
+    , default =
+        { podMetadata = None Kubernetes.ObjectMeta.Type
+        , serviceMonitorSelector = None Kubernetes.LabelSelector.Type
+        , serviceMonitorNamespaceSelector = None Kubernetes.LabelSelector.Type
+        , podMonitorSelector = None Kubernetes.LabelSelector.Type
+        , podMonitorNamespaceSelector = None Kubernetes.LabelSelector.Type
+        , version = None Text
+        , tag = None Text
+        , sha = None Text
+        , paused = None Bool
+        , image = None Text
+        , baseImage = None Text
+        , imagePullSecrets = None (List Kubernetes.LocalObjectReference.Type)
+        , replicas = None Natural
+        , replicaExternalLabelName = None Text
+        , prometheusExternalLabelName = None Text
+        , retention = None Text
+        , retentionSize = None Text
+        , disableCompaction = None Bool
+        , walCompression = None Bool
+        , logLevel = None Text
+        , logFormat = None Text
+        , scrapeInterval = None Text
+        , evaluationInterval = None Text
+        , rules = None Rules.Type
+        , externalLabels = None (Map Text Text)
+        , enableAdminAPI = None Bool
+        , externalUrl = None Text
+        , routePrefix = None Text
+        , query = None QuerySpec.Type
+        , storage = None StorageSpec
+        , volumes = None (List Kubernetes.Volume.Type)
+        , ruleSelector = None Kubernetes.LabelSelector.Type
+        , ruleNamespaceSelector = None Kubernetes.LabelSelector.Type
+        , alerting = None AlertingSpec.Type
+        , resources = None Kubernetes.ResourceRequirements.Type
+        , nodeSelector = None (Map Text Text)
+        , serviceAccountName = None Text
+        , secrets = None (List Text)
+        , configMaps = None (List Text)
+        , affinity = None Kubernetes.Affinity.Type
+        , tolerations = None (List Kubernetes.Toleration.Type)
+        , remoteWrite = None (List RemoteWriteSpec.Type)
+        , remoteRead = None (List RemoteReadSpec.Type)
+        , securityContext = None Kubernetes.PodSecurityContext.Type
+        , listenLocal = None Bool
+        , containers = None (List Kubernetes.Container.Type)
+        , initContainers = None (List Kubernetes.Container.Type)
+        , additionalScrapeConfigs = None Kubernetes.SecretKeySelector.Type
+        , additionalAlertRelabelConfigs = None Kubernetes.SecretKeySelector.Type
+        , additionalAlertManagerConfigs = None Kubernetes.SecretKeySelector.Type
+        , apiserverConfig = None APIServerConfig.Union
+        , thanos = None ThanosSpec.Type
+        , priorityClassName = None Text
+        , portName = None Text
+        , arbitraryFSAccessThroughSMs =
+            None ArbitraryFSAccessThroughSMsConfig.Type
+        , overrideHonorLabels = None Bool
+        , overrideHonorTimestamps = None Bool
+        , ignoreNamespaceSelectors = None Bool
+        , enforcedNamespaceLabel = None Text
+        }
+    }

--- a/v1/RelabelConfig.dhall
+++ b/v1/RelabelConfig.dhall
@@ -5,7 +5,7 @@ let RelabelConfig =
           , regex : Optional Text
           , replacement : Optional Text
           , separator : Optional Text
-          , sourceLabels : List Text
+          , sourceLabels : Optional (List Text)
           , targetLabel : Optional Text
           }
       , default =
@@ -14,7 +14,7 @@ let RelabelConfig =
           , regex = None Text
           , replacement = None Text
           , separator = None Text
-          , sourceLabels = [] : List Text
+          , sourceLabels = None (List Text)
           , targetLabel = None Text
           }
       }

--- a/v1/RemoteReadSpec.dhall
+++ b/v1/RemoteReadSpec.dhall
@@ -7,7 +7,7 @@ let TLSConfig = ./TLSConfig.dhall
 let RemoteReadSpec =
       { Type =
           { url : Text
-          , requiredMatchers : Map Text Text
+          , requiredMatchers : Optional (Map Text Text)
           , remoteTimeout : Optional Text
           , readRecent : Optional Bool
           , basicAuth : Optional BasicAuth.Type
@@ -17,7 +17,7 @@ let RemoteReadSpec =
           , proxyUrl : Optional Text
           }
       , default =
-          { requiredMatchers = [] : Map Text Text
+          { requiredMatchers = None (Map Text Text)
           , remoteTimeout = None Text
           , readRecent = None Bool
           , basicAuth = None BasicAuth.Type

--- a/v1/RemoteWriteSpec.dhall
+++ b/v1/RemoteWriteSpec.dhall
@@ -10,7 +10,7 @@ let RemoteWriteSpec =
       { Type =
           { url : Text
           , remoteTimeout : Optional Text
-          , writeRelabelConfigs : List RelabelConfig.Type
+          , writeRelabelConfigs : Optional (List RelabelConfig.Type)
           , basicAuth : Optional BasicAuth.Type
           , bearerToken : Optional Text
           , bearerTokenFile : Optional Text
@@ -20,7 +20,7 @@ let RemoteWriteSpec =
           }
       , default =
           { remoteTimeout = None Text
-          , writeRelabelConfigs = [] : List RelabelConfig.Type
+          , writeRelabelConfigs = None (List RelabelConfig.Type)
           , basicAuth = None BasicAuth.Type
           , bearerToken = None Text
           , bearerTokenFile = None Text

--- a/v1/Rule.dhall
+++ b/v1/Rule.dhall
@@ -10,15 +10,15 @@ let Rule =
           , alert : Optional Text
           , expr : IntOrString
           , for : Optional Text
-          , labels : Map Text Text
-          , annotations : Map Text Text
+          , labels : Optional (Map Text Text)
+          , annotations : Optional (Map Text Text)
           }
       , default =
           { record = None Text
           , alert = None Text
           , for = None Text
-          , labels = [] : Map Text Text
-          , annotations = [] : Map Text Text
+          , labels = None (Map Text Text)
+          , annotations = None (Map Text Text)
           }
       }
 

--- a/v1/RuleGroup.dhall
+++ b/v1/RuleGroup.dhall
@@ -1,8 +1,12 @@
 let Rule = ./Rule.dhall
 
 let RuleGroup =
-      { Type = { name : Text, interval : Optional Text, rules : List Rule.Type }
-      , default = { interval = None Text, rules = [] : List Rule.Type }
+      { Type =
+          { name : Text
+          , interval : Optional Text
+          , rules : Optional (List Rule.Type)
+          }
+      , default = { interval = None Text, rules = None (List Rule.Type) }
       }
 
 let test = RuleGroup::{ name = "example" }

--- a/v1/ServiceMonitor.dhall
+++ b/v1/ServiceMonitor.dhall
@@ -4,25 +4,12 @@ let Kubernetes = imports.Kubernetes
 
 let ServiceMonitorSpec = ./ServiceMonitorSpec.dhall
 
-let ServiceMonitor =
-      { Type =
-          { apiVersion : Text
-          , kind : Text
-          , metadata : Kubernetes.ObjectMeta.Type
-          , spec : ServiceMonitorSpec.Type
-          }
-      , default =
-          { apiVersion = "monitoring.coreos.com/v1", kind = "ServiceMonitor" }
-      }
-
-let test =
-      let ServiceMonitorSpec = ./ServiceMonitorSpec.dhall
-
-      in  ServiceMonitor::{
-          , metadata = Kubernetes.ObjectMeta::{ name = "example" }
-          , spec = ServiceMonitorSpec::{
-            , selector = Kubernetes.LabelSelector::{=}
-            }
-          }
-
-in  ServiceMonitor
+in  { Type =
+        { apiVersion : Text
+        , kind : Text
+        , metadata : Kubernetes.ObjectMeta.Type
+        , spec : ServiceMonitorSpec.Type
+        }
+    , default =
+        { apiVersion = "monitoring.coreos.com/v1", kind = "ServiceMonitor" }
+    }

--- a/v1/ServiceMonitorList.dhall
+++ b/v1/ServiceMonitorList.dhall
@@ -2,21 +2,15 @@ let Kubernetes = (../imports.dhall).Kubernetes
 
 let ServiceMonitor = ./ServiceMonitor.dhall
 
-let ServiceMonitorList =
-      { Type =
-          { apiVersion : Text
-          , kind : Text
-          , metadata : Kubernetes.ListMeta.Type
-          , items : List ServiceMonitor.Type
-          }
-      , default =
-          { apiVersion = "monitoring.coreos.com/v1"
-          , kind = "ServiceMonitorList"
-          , metadata = Kubernetes.ListMeta::{=}
-          , items = [] : List ServiceMonitor.Type
-          }
-      }
-
-let test = ServiceMonitorList::{=}
-
-in  ServiceMonitorList
+in  { Type =
+        { apiVersion : Text
+        , kind : Text
+        , metadata : Kubernetes.ListMeta.Type
+        , items : Optional (List ServiceMonitor.Type)
+        }
+    , default =
+        { apiVersion = "monitoring.coreos.com/v1"
+        , kind = "ServiceMonitorList"
+        , items = None (List ServiceMonitor.Type)
+        }
+    }

--- a/v1/ServiceMonitorSpec.dhall
+++ b/v1/ServiceMonitorSpec.dhall
@@ -6,26 +6,21 @@ let Endpoint = ./Endpoint.dhall
 
 let NamespaceSelector = ./NamespaceSelector.dhall
 
-let ServiceMonitorSpec =
-      { Type =
-          { jobLabel : Optional Text
-          , targetLabels : List Text
-          , podTargetLabels : List Text
-          , endpoints : List Endpoint.Union
-          , selector : Kubernetes.LabelSelector.Type
-          , namespaceSelector : Optional NamespaceSelector
-          , sampleLimit : Optional Natural
-          }
-      , default =
-          { jobLabel = None Text
-          , targetLabels = [] : List Text
-          , podTargetLabels = [] : List Text
-          , endpoints = [] : List Endpoint.Union
-          , namespaceSelector = None NamespaceSelector
-          , sampleLimit = None Natural
-          }
-      }
-
-let test = ServiceMonitorSpec::{ selector = Kubernetes.LabelSelector::{=} }
-
-in  ServiceMonitorSpec
+in  { Type =
+        { jobLabel : Optional Text
+        , targetLabels : Optional (List Text)
+        , podTargetLabels : Optional (List Text)
+        , endpoints : Optional (List Endpoint.Union)
+        , selector : Kubernetes.LabelSelector.Type
+        , namespaceSelector : Optional NamespaceSelector
+        , sampleLimit : Optional Natural
+        }
+    , default =
+        { jobLabel = None Text
+        , targetLabels = None (List Text)
+        , podTargetLabels = None (List Text)
+        , endpoints = None (List Endpoint.Union)
+        , namespaceSelector = None NamespaceSelector
+        , sampleLimit = None Natural
+        }
+    }

--- a/v1/StorageSpec.dhall
+++ b/v1/StorageSpec.dhall
@@ -9,20 +9,4 @@ let StorageSpec =
       | VolumeClaimTemplate : { volumeClaimTemplate : VolumeClaimTemplate.Type }
       >
 
-let test =
-      let VolumeClaimTemplate = ./VolumeClaimTemplate.dhall
-
-      let VolumeClaimTemplateSpec = ./VolumeClaimTemplateSpec.dhall
-
-      in  { emptyDir =
-              StorageSpec.EmptyDir
-                { emptyDir = Kubernetes.EmptyDirVolumeSource::{=} }
-          , volumeClaimTemplate =
-              StorageSpec.VolumeClaimTemplate
-                { volumeClaimTemplate = VolumeClaimTemplate::{
-                  , spec = VolumeClaimTemplateSpec::{=}
-                  }
-                }
-          }
-
 in  StorageSpec

--- a/v1/VolumeClaimTemplateSpec.dhall
+++ b/v1/VolumeClaimTemplateSpec.dhall
@@ -2,7 +2,7 @@ let Kubernetes = (../imports.dhall).Kubernetes
 
 let VolumeClaimTemplateSpec =
       { Type =
-          { accessModes : List Text
+          { accessModes : Optional (List Text)
           , resources : Optional Kubernetes.ResourceRequirements.Type
           , selector : Optional Kubernetes.LabelSelector.Type
           , storageClassName : Optional Text
@@ -10,7 +10,7 @@ let VolumeClaimTemplateSpec =
           , volumeName : Optional Text
           }
       , default =
-          { accessModes = [] : List Text
+          { accessModes = None (List Text)
           , resources = None Kubernetes.ResourceRequirements.Type
           , selector = None Kubernetes.LabelSelector.Type
           , storageClassName = None Text


### PR DESCRIPTION
Upstream `dhall-kubernetes` has returned to using the default behavior
of omitting empty Optionals instead of the `--omit-empty` behavior that
it had embraced earlier.

This change updates `dhall-prometheus-operator` to return to the use of
`Optional List X` instead of `List X` in turn.